### PR TITLE
Adding Announcement Section and corresponding check boxes to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
@@ -31,7 +31,7 @@ or
 
 # Announcement Message
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
-devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A"
+devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A" >
 
 # Subject Domain Experts
 < list of subject domain experts for this domain. If the subject expert from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >

--- a/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
@@ -31,7 +31,7 @@ or
 
 # Announcement Message
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
-devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A" >
+crumpet: < If Team Crumpet requires notification instead of the end user or if there is different information for Team Crumpet, then put the text here. Otherwise indicate "N/A" >
 
 # Subject Domain Experts
 < list of subject domain experts for this domain. If the subject expert from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >

--- a/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
@@ -31,7 +31,8 @@ or
 
 # Announcement Message
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
-crumpet: < If Team Crumpet requires notification instead of the end user or if there is different information for Team Crumpet, then put the text here. Otherwise indicate "N/A" >
+
+devchat: < If Team Crumpet requires notification instead of the end user or if there is different information for Team Crumpet, then put the text here. Otherwise indicate "N/A" >
 
 # Subject Domain Experts
 < list of subject domain experts for this domain. If the subject expert from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >

--- a/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
@@ -32,7 +32,7 @@ or
 # Announcement Message
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
 
-devchat: < If Team Crumpet requires notification instead of the end user or if there is different information for Team Crumpet, then put the text here. Otherwise indicate "N/A" >
+devchat: < If Hl Engineering requires notification instead of the end user or if there is different information, then put the text here. Otherwise indicate "N/A" >
 
 # Subject Domain Experts
 < list of subject domain experts for this domain. If the subject expert from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >

--- a/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
@@ -29,6 +29,10 @@ or
 
 - [ ] Bug could not be reproduced but addditional logging has been added
 
+# Announcement Message
+releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
+devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A"
+
 # Subject Domain Experts
 < list of subject domain experts for this domain. If the subject expert from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >
 
@@ -49,6 +53,7 @@ or
 - [ ] Issue scored
 - [ ] Special testing instructions noted
 - [ ] Acceptance criteria met - boxes checked
+- [ ] Announcement message created
 
 ### Ready for SM Approval
 - [ ] Manual Acceptance Test Results included in Comment
@@ -56,3 +61,4 @@ or
 ### Ready for PO Approval
 - [ ] Issue complete and correct in all required sections
 - [ ] All checkboxes checked
+- [ ] Announcement message approved

--- a/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
@@ -18,6 +18,7 @@ labels: Feature
  
 # Announcement Message
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
+
 devchat: < If HL Engineering requires notification instead of the end user or if there is different information, then put the text here. Otherwise indicate "N/A" >
 
 # Subject Domain Experts

--- a/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
@@ -16,6 +16,10 @@ labels: Feature
 # Acceptance Criteria
 < list of behaviors that must be present in order to satisfy the required functionality described above. >
  
+# Announcement Message
+releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
+devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A" >
+
 # Subject Domain Experts
 < list of subject domain experts for this domain. If the subject expert from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >
 
@@ -36,6 +40,7 @@ labels: Feature
 - [ ] Issue scored
 - [ ] Special testing instructions noted
 - [ ] Acceptance criteria met - boxes checked
+- [ ] Announcement message created
 
 ### Ready for SM Approval
 - [ ] Manual Acceptance Test Results included in Comment
@@ -43,3 +48,4 @@ labels: Feature
 ### Ready for PO Approval
 - [ ] Issue complete and correct in all required sections
 - [ ] All checkboxes checked
+- [ ] Announcement message approved

--- a/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
@@ -18,7 +18,7 @@ labels: Feature
  
 # Announcement Message
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
-devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A" >
+devchat: < If HL Engineering requires notification instead of the end user or if there is different information, then put the text here. Otherwise indicate "N/A" >
 
 # Subject Domain Experts
 < list of subject domain experts for this domain. If the subject expert from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >

--- a/.github/ISSUE_TEMPLATE/Standard-Technical-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Technical-Issue-Template.md
@@ -25,6 +25,10 @@ labels: Technical
 # Acceptance Criteria
 < list of behaviors that must be present in order to satisfy the required functionality described above. >
 
+# Announcement Message
+releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
+devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A" >
+
 # Progress
 ### Ready for Planning
 - [ ] Story and Business Value complete
@@ -39,6 +43,7 @@ labels: Technical
 - [ ] Issue scored
 - [ ] Special testing instructions noted
 - [ ] Acceptance criteria met - boxes checked
+- [ ] Announcement message created
 
 ### Ready for SM Approval
 - [ ] Manual Acceptance Test Results included in Comment
@@ -46,3 +51,4 @@ labels: Technical
 ### Ready for PO Approval
 - [ ] Issue complete and correct in all required sections
 - [ ] All checkboxes checked
+- [ ] Announcement message approved

--- a/.github/ISSUE_TEMPLATE/Standard-Technical-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Technical-Issue-Template.md
@@ -27,7 +27,8 @@ labels: Technical
 
 # Announcement Message
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
-devteam: < If Dev Team requires notification instead of the end user or if there is different information for the dev team, then put the text here. Otherwise indicate "N/A" >
+
+devchat: < If HL Engineering requires notification instead of the end user or if there is different information, then put the text here. Otherwise indicate "N/A" >
 
 # Progress
 ### Ready for Planning


### PR DESCRIPTION
Just changed Issue templates to add a section where the developer would add the text used to notify users and/or Dev team on Slack in releasenotes and/or DevChat