### PR TITLE
Remove progress sections from all templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
@@ -39,33 +39,3 @@ devchat: < If Hl Engineering requires notification instead of the end user or if
 
 ## Subject Matter Experts
 < list of subject matter experts for this domain. If the SME from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >
-
-## Progress
-### Fully Created Issues - completed by author
-- [ ] Description completed
-- [ ] Acceptance Criteria Specified
-- [ ] Approver Identified
-- [ ] Labels attached
-- [ ] QA Needs provided
-- [ ] SME's provided
-
-### SME Reviewed Issues - completed by SM & Team Leads
-- [ ] Description approved
-- [ ] Acceptance Criteria Finalized
-- [ ] Approver correct
-- [ ] Appropriate labels attached
-- [ ] QA Needs reviewed
-- [ ] SME list complete
-
-### Implemented Issue - completed by Developer assigned
-- [ ] Issue scored
-- [ ] Acceptance criteria met - boxes checked
-- [ ] Announcement message created
-
-### Tested Issue - Completed by QA assigned
-- [ ] Manual Acceptance Test Results included in Comment
-
-### Deploy-able Issue - completed by SM
-- [ ] Announcement message approved
-- [ ] Issue complete and correct in all required sections
-- [ ] Acceptance Criteria met

--- a/.github/ISSUE_TEMPLATE/Standard-Dependencies-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Dependencies-Issue-Template.md
@@ -30,24 +30,3 @@ labels: dependencies
 releasenotes: Changes have been made that affect < some portion of the system >. Please let us know if you have any difficulties < doing whatever they do with that part of the system  >
 
 devchat: < Dependency name > has been updated to <dependency target version> See <link to new features or this Issue > for available features and fixes
-
-## Progress
-### DM Reviewed Issues - completed by Dependency Maintainer
-- [ ] Description completed
-- [ ] Acceptance Criteria Specified
-- [ ] Approver Identified
-- [ ] Labels attached
-- [ ] QA Needs provided
-
-### Implemented Issue - completed by Developer assigned
-- [ ] Issue scored
-- [ ] Acceptance criteria met - boxes checked
-- [ ] Announcement message created
-
-### Tested Issue - Completed by QA assigned
-- [ ] Manual Acceptance Test Results included in Comment
-
-### Deploy-able Issue - completed by SM
-- [ ] Announcement message approved
-- [ ] Issue complete and correct in all required sections
-- [ ] Acceptance Criteria met

--- a/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Feature-Issue-Template.md
@@ -26,32 +26,3 @@ devchat: < If HL Engineering requires notification instead of the end user or if
 
 ## Subject Matter Experts
 < list of subject matter experts for this domain. If the SME from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >
-
-## Progress
-### Fully Created Issues - completed by author
-- [ ] Story and Business Value complete
-- [ ] Acceptance Criteria Specified
-- [ ] Approver Identified
-- [ ] Labels attached
-- [ ] QA Needs provided
-- [ ] SME's provided
-
-### SME Reviewed Issues - completed by SM & Team Leads
-- [ ] Story and Business Value approved
-- [ ] Acceptance Criteria Finalized
-- [ ] Approver correct
-- [ ] Appropriate labels attached
-- [ ] SME list complete
-
-### Implemented Issue - completed by Developer assigned
-- [ ] Issue scored
-- [ ] Acceptance criteria met - boxes checked
-- [ ] Announcement message created
-
-### Tested Issue - Completed by QA assigned
-- [ ] Manual Acceptance Test Results included in Comment
-
-### Deploy-able Issue - completed by SM
-- [ ] Announcement message approved
-- [ ] Issue complete and correct in all required sections
-- [ ] Acceptance Criteria met

--- a/.github/ISSUE_TEMPLATE/Standard-Investigation-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Investigation-Issue-Template.md
@@ -24,26 +24,3 @@ or
 
 ## Subject Matter Experts
 < list of subject matter experts for this domain. If the SME from the end-user perspective is not the author, an end-user expert should be listed here. The Design, Dev, and QA teams should add experts here as appropriate. >
-
-## Progress
-### Fully Created Issues - completed by author
-- [ ] Inspiration and Value completed
-- [ ] Acceptance Criteria Specified
-- [ ] Approver Identified
-- [ ] Labels attached
-- [ ] SME's provided
-
-### SME Reviewed Issues - completed by SM & Team Leads
-- [ ] Description approved
-- [ ] Acceptance Criteria Finalized
-- [ ] Approver correct
-- [ ] Appropriate labels attached
-- [ ] SME list complete
-
-### Implemented Issue - completed by Developer assigned
-- [ ] Issue scored
-- [ ] Acceptance criteria selected and met - boxes checked
-
-### Deploy-able Issue - completed by SM
-- [ ] Issue complete and correct in all required sections
-- [ ] Acceptance Criteria met

--- a/.github/ISSUE_TEMPLATE/Standard-Technical-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Technical-Issue-Template.md
@@ -29,32 +29,3 @@ labels: Technical
 releasenotes: < if the Issue is something visible to the end user, then put the text for the releasenotes slack channel here. Otherwise indicate "N/A" >
 
 devchat: < If HL Engineering requires notification instead of the end user or if there is different information, then put the text here. Otherwise indicate "N/A" >
-
-## Progress
-### Fully Created Issues - completed by author
-- [ ] Description completed
-- [ ] Acceptance Criteria Specified
-- [ ] Approver Identified
-- [ ] Labels attached
-- [ ] QA Needs provided
-
-### SME Reviewed Issues - completed by SM & Team Leads
-- [ ] Description approved
-- [ ] Acceptance Criteria Finalized
-- [ ] Approver correct
-- [ ] Appropriate labels attached
-- [ ] QA Needs reviewed
-
-
-### Implemented Issue - completed by Developer assigned
-- [ ] Issue scored
-- [ ] Acceptance criteria met - boxes checked
-- [ ] Announcement message created
-
-### Tested Issue - Completed by QA assigned
-- [ ] Manual Acceptance Test Results included in Comment
-
-### Deploy-able Issue - completed by SM
-- [ ] Announcement message approved
-- [ ] Issue complete and correct in all required sections
-- [ ] Issue requirements met


### PR DESCRIPTION
In an effort to remove things that just aren't getting used and don't appear necessary, I am removing the Progress check box sections from all templates. There is no testing required.