### PR TITLE
Add template for IFT/CFTs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Standard-Intermittently-Failing-Test.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Intermittently-Failing-Test.md
@@ -1,0 +1,19 @@
+---
+name: Intermittently Failing Test Issue
+about: Use this template for IFT and CFT issues
+labels: Intermittently Failing Test
+---
+
+## Description
+- Include the name, scenario, path, etc of the failing test(s)
+
+## Output
+```
+Paste output from CI here
+```
+
+## Examples from CI
+* Include links to failing builds
+
+## Acceptance Criteria
+- [ ] The cause of the failing test has been determined and fixed


### PR DESCRIPTION
### Description
I've been wanting an issue template for IFT/CFT issues for a while. Should save me a little time trying to format the description for each issue I create. Also reduces the likelihood I'll forget to add acceptance criteria.