### PR TITLE
Remove "Requirements to cover in Issues" section

### DIFF
--- a/.github/ISSUE_TEMPLATE/Standard-Epic-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Epic-Template.md
@@ -12,10 +12,4 @@ about: Use this template for all Epics
 ## Notes
 < list of special notes or suggestions to the development team on the implementation of the changes. >  
 
-## Requirements to cover in Issues:
-< checkbox list of requirements, features, etc. that will be used when creating Issues for the Epic to ensure that all requirements for the functionality overall has been addressed in an Issue. Check off the requirements as you cover them in the Issues created. > 
-- [ ] Requirement 1
-- [ ] Requirement 2
-- [ ] Requirement 3
-
 NOTE: YOU MUST CHANGE THE ISSUE TO AN EPIC AFTER YOU CREATE IT!


### PR DESCRIPTION
I feel that this section is redundant. After creating the Epic, the author should immediately create the issues and add them to the Epic. The issue titles will then be listed on the Epic immediately below the main Epic description. If the "Requirements to cover in Issues" section is just a repeat of the issue titles, which IMHO it pretty much always is, then creating it is a waste of time.