### PR TITLE
Fix spelling that is triggering when I open a bug using template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Standard-Bug-Issue-Template.md
@@ -27,7 +27,7 @@ labels: Bug
 
 or
 
-- [ ] Bug could not be reproduced but addditional logging has been added
+- [ ] Bug could not be reproduced but additional logging has been added
 
 ## Announcement Message
 releasenotes: < if the Issue is something that could affect the end user, then put the text for the releasenotes Slack channel here. Otherwise. indicate "N/A" >


### PR DESCRIPTION
For Humanities Sake

BUG FIX:

**Cause:**
Reduce stress induce anxiety when I use the bug template to create an issue

**Solution:**
Remove the `d`


