### PR TITLE
Add reusable ng-checkout bump label workflow

### DIFF
--- a/.github/workflows/label-ng-checkout-bump.yml
+++ b/.github/workflows/label-ng-checkout-bump.yml
@@ -24,7 +24,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -eu
+          set -euo pipefail
 
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           [ "$CHANGED" = ".env.example" ] || { echo "Other files changed, skipping."; exit 0; }

--- a/.github/workflows/label-ng-checkout-bump.yml
+++ b/.github/workflows/label-ng-checkout-bump.yml
@@ -1,0 +1,39 @@
+name: Label ng-checkout bump
+
+on:
+  workflow_call:
+    secrets:
+      repo_pat:
+        required: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Add ng-checkout bump label
+        env:
+          GH_TOKEN: ${{ secrets.repo_pat }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          [ "$CHANGED" = ".env.example" ] || { echo "Other files changed, skipping."; exit 0; }
+
+          DIFF=$(git diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- .env.example | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)
+          [ -n "$DIFF" ] || { echo "No effective diff, skipping."; exit 0; }
+
+          OTHER=$(printf '%s\n' "$DIFF" | grep -vE '^[+-]NG_CHECKOUT_RELEASE_TAG=' || true)
+          [ -z "$OTHER" ] || { echo "More than NG_CHECKOUT_RELEASE_TAG changed, skipping."; exit 0; }
+
+          echo "Adding ng-checkout-bump label."
+          gh pr edit "$PR_NUMBER" --add-label "ng-checkout-bump"


### PR DESCRIPTION
For https://github.com/Medology/Arepa/issues/1590

FEATURE IMPLEMENTATION:

This PR centralizes the ng-checkout bump labeling workflow into `Medology/.github` so parent repos in the org can reuse the same implementation instead of maintaining local copies.

This is based on the workflow introduced in https://github.com/Medology/www.starfish.com/pull/1579.

**How it works**

- Added `.github/workflows/label-ng-checkout-bump.yml` as a reusable workflow with `workflow_call`
- Accepts a caller-provided PAT secret for writing the `ng-checkout-bump` label
- Keeps the same workflow implementation already merged in `www.starfish.com`
- Lets each consuming repo keep a thin caller workflow for its own trigger conditions and secret wiring

**Verification**

- The underlying workflow logic was introduced in https://github.com/Medology/www.starfish.com/pull/1579
- A real bump PR in `www.starfish.com` exercised the merged workflow and attempted the automatic label path: https://github.com/Medology/www.starfish.com/pull/1600
- After this merges, other org repos can opt in by adding a thin caller workflow that uses this reusable workflow
